### PR TITLE
Don't use percentage based height

### DIFF
--- a/src/styles/_navBar.scss
+++ b/src/styles/_navBar.scss
@@ -7,7 +7,6 @@ nav {
   overflow: hidden;
   align-items: baseline;
   vertical-align: middle;
-  height: 4vh;
   font-size: 2vh;
 
   @mixin navbarItems() {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -11,7 +11,6 @@ nav {
       -ms-flex-align: baseline;
           align-items: baseline;
   vertical-align: middle;
-  height: 4vh;
   font-size: 2vh;
 }
 


### PR DESCRIPTION
The navigation bar now uses a fixed height, to fit the content, instead of using a percentage of the viewport, which could cut off content, and made the dropdown not appear connected to the navigation bar.